### PR TITLE
Support jobs

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -32,6 +32,7 @@ stages:
             description="The ${ESTAFETTE_GIT_NAME} component is an Estafette extension to deploy applications to a Kubernetes Engine cluster using a simple kubernetes.yaml file"
 
       RUN apk update \
+          && apk upgrade \
           && apk add --upgrade gnupg \
           && rm /var/cache/apk/*
 

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -26,7 +26,7 @@ stages:
     image: extensions/docker:dev
     action: build
     inline: |
-      FROM gcr.io/google.com/cloudsdktool/cloud-sdk:329.0.0-alpine
+      FROM gcr.io/google.com/cloudsdktool/cloud-sdk:331.0.0-alpine
 
       LABEL maintainer="estafette.io" \
             description="The ${ESTAFETTE_GIT_NAME} component is an Estafette extension to deploy applications to a Kubernetes Engine cluster using a simple kubernetes.yaml file"

--- a/main.go
+++ b/main.go
@@ -196,6 +196,33 @@ func main() {
 		log.Debug().Msgf("%v\n", renderedManifestContent)
 	}
 
+	if *releaseAction == "delete" {
+		// dry-run manifests
+		log.Info().Msg("\nDRYRUN\n")
+		for _, m := range params.Manifests {
+			kubectlDeleteArgs := []string{"delete", "-f", filepath.Join(renderedDir, m), "-n", params.Namespace}
+
+			foundation.RunCommandWithArgs(ctx, "kubectl", append(kubectlDeleteArgs, "--dry-run=server"))
+		}
+
+		if params.DryRun {
+			return
+		}
+
+		log.Info().Msg("\nDELETE\n")
+
+		// delete resources
+		for _, m := range params.Manifests {
+			kubectlDeleteArgs := []string{"delete", "-f", filepath.Join(renderedDir, m), "-n", params.Namespace}
+
+			// delete resources from manifest
+			log.Info().Msgf("Deleting resources defined in the manifest '%v'...", m)
+			foundation.RunCommandWithArgs(ctx, "kubectl", kubectlDeleteArgs)
+		}
+
+		return
+	}
+
 	// dry-run manifests
 	log.Info().Msg("\nDRYRUN\n")
 	for _, m := range params.Manifests {

--- a/main.go
+++ b/main.go
@@ -292,14 +292,18 @@ func main() {
 						log.Info().Msgf("Job '%v' finished successfully.", job)
 						break
 					} else {
-						time.Sleep(time.Microsecond * 100)
+						time.Sleep(time.Second * 2)
 					}
 				}
 			}
 			if timeout {
 				out, _ := foundation.GetCommandWithArgsOutput(ctx, "kubectl", []string{"logs", "job/" + job, "-n", params.Namespace})
-				log.Info().Msgf("Job '%v' timed-out.\nLogs:\n%s", job, out)
+				log.Error().Msgf("Job '%v' timed-out.\nLogs:\n%s", job, out)
 			}
+		}
+
+		if timeout {
+			log.Fatal().Msgf("Job(s) failed to complete successfully within timeout %d seconds.", params.JobTimeoutSeconds)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -315,7 +315,7 @@ func main() {
 				log.Info().Msgf("Waiting for job '%v' to finish...", job)
 				for !timeout {
 					out, _ := foundation.GetCommandWithArgsOutput(ctx, "kubectl", []string{"get", "job", job, "-n", params.Namespace, "-o", "jsonpath='{.status.succeeded}'"})
-					if out == "1" {
+					if strings.Compare(out, "'1'") == 0 {
 						log.Info().Msgf("Job '%v' finished successfully.", job)
 						break
 					} else {

--- a/main.go
+++ b/main.go
@@ -307,13 +307,14 @@ func main() {
 		timeoutChan := time.After(time.Second * time.Duration(params.JobTimeoutSeconds))
 		for _, job := range params.Jobs {
 			log.Info().Msgf("Waiting for job '%v' to finish...", job)
+		JobWaitLoop:
 			for {
 				select {
 				default:
 					out, _ := foundation.GetCommandWithArgsOutput(ctx, "kubectl", []string{"get", "job", job, "-n", params.Namespace, "-o", "jsonpath='{.status.succeeded}'"})
 					if strings.Compare(out, "'1'") == 0 {
 						log.Info().Msgf("Job '%v' finished successfully.", job)
-						break
+						break JobWaitLoop
 					} else {
 						time.Sleep(time.Second * 2)
 					}

--- a/params.go
+++ b/params.go
@@ -9,12 +9,15 @@ type Params struct {
 	Deployments  []string `json:"deployments,omitempty" yaml:"deployments,omitempty"`
 	Statefulsets []string `json:"statefulsets,omitempty" yaml:"statefulsets,omitempty"`
 	Daemonsets   []string `json:"daemonsets,omitempty" yaml:"daemonsets,omitempty"`
+	Jobs         []string `json:"jobs,omitempty" yaml:"jobs,omitempty"`
 
 	Placeholders map[string]string `json:"placeholders,omitempty" yaml:"placeholders,omitempty"`
 
 	AwaitZeroReplicas bool `json:"awaitZeroReplicas,omitempty" yaml:"awaitZeroReplicas,omitempty"`
 
 	DryRun bool `json:"dryrun,omitempty" yaml:"dryrun,omitempty"`
+
+	JobTimeoutSeconds int `json:"jobtimeoutseconds,omitempty" yaml:"jobtimeoutseconds,omitempty"`
 }
 
 // SetDefaults fills in empty fields with convention-based defaults


### PR DESCRIPTION
Added support for `Jobs` and to wait till job is successfully completed till timeout.
Added `delete` action to remove resources defined in provided manifests. This is required as modification to Job is not possible after it is applied.